### PR TITLE
Enh/nav

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import NavBar from '@/components/NavBar';
+import { NavBar } from '@/components/layout';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -5,7 +5,7 @@ import {
   updateVocabItem,
 } from '@/lib/actions/vocab-actions';
 import { ROUTES } from '@/lib/constants/routes';
-import { House, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import Link from 'next/link';
 import { Suspense } from 'react';
 
@@ -26,9 +26,6 @@ export default async function VocabPage() {
           <nav className="flex absolute right-0 gap-2">
             <Link href={ROUTES.ADD_VOCAB} scroll={false}>
               <Plus size={32} />
-            </Link>
-            <Link href={ROUTES.HOME}>
-              <House size={32} />
             </Link>
           </nav>
         </header>

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,1 +1,2 @@
 export { Modal } from './modal';
+export { NavBar } from './nav-bar';

--- a/src/components/layout/nav-bar.tsx
+++ b/src/components/layout/nav-bar.tsx
@@ -1,14 +1,14 @@
 import { ROUTES } from '@/lib/constants/routes';
-import { BookType, Heart, Info } from 'lucide-react';
+import { BookType, Info, UserRound } from 'lucide-react';
 import Link from 'next/link';
 
-export default function NavBar() {
+export function NavBar() {
   return (
     <nav className="mb-4 py-4">
       <ul className="flex justify-around">
         <li>
-          <Link href={ROUTES.USER_GUIDE}>
-            <Info size={32} />
+          <Link href={ROUTES.ACCOUNT}>
+            <UserRound size={32} />
           </Link>
         </li>
         <li>
@@ -17,8 +17,8 @@ export default function NavBar() {
           </Link>
         </li>
         <li>
-          <Link href={ROUTES.HEALTH_CHECK}>
-            <Heart size={32} />
+          <Link href={ROUTES.USER_GUIDE}>
+            <Info size={32} />
           </Link>
         </li>
       </ul>

--- a/src/components/layout/nav-bar.tsx
+++ b/src/components/layout/nav-bar.tsx
@@ -1,8 +1,14 @@
+'use client';
+
 import { ROUTES } from '@/lib/constants/routes';
-import { BookType, Info, UserRound } from 'lucide-react';
+import { BookType, Home, Info, UserRound } from 'lucide-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 export function NavBar() {
+  const pathname = usePathname();
+  const isHome = pathname === ROUTES.HOME;
+
   return (
     <nav className="mb-4 py-4">
       <ul className="flex justify-around">
@@ -12,8 +18,8 @@ export function NavBar() {
           </Link>
         </li>
         <li>
-          <Link href={ROUTES.VOCAB}>
-            <BookType size={32} />
+          <Link href={isHome ? ROUTES.VOCAB : ROUTES.HOME}>
+            {isHome ? <BookType size={32} /> : <Home size={32} />}
           </Link>
         </li>
         <li>

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -1,8 +1,9 @@
 export const ROUTES = {
   HOME: '/',
+  ACCOUNT: '/',
   VOCAB: '/vocab',
   ADD_VOCAB: '/add-vocab',
   TEST: '/test',
   USER_GUIDE: '/user-guide',
-  HEALTH_CHECK: '',
+  HEALTH_CHECK: '/',
 } as const;


### PR DESCRIPTION
### What changed
- NavBar icons are now (l-r) 'Account', 'Home' or 'Vocab', and 'User Guide'
  - 'Home' icon is default, but changes to 'Vocab' when on Home page already
- Removed redundant 'Home' icon in top-right of vocab page 
- `nav-bar.tsx` is now in `components\layout` with barrel import
- Added 'ACCOUNT' route constant